### PR TITLE
feat: Auto-unlock Erekir research on new campaign startup

### DIFF
--- a/core/src/mindustry/content/ErekirTechTree.java
+++ b/core/src/mindustry/content/ErekirTechTree.java
@@ -8,6 +8,10 @@ import mindustry.type.*;
 import mindustry.type.unit.*;
 import mindustry.world.blocks.defense.turrets.*;
 
+// Ensure these imports are present
+import mindustry.Vars;
+import mindustry.content.TechTree.TechNode;
+
 import static mindustry.Vars.*;
 import static mindustry.content.Blocks.*;
 import static mindustry.content.SectorPresets.*;
@@ -465,6 +469,22 @@ public class ErekirTechTree{
                     });
                 });
             });
+        });
+    }
+
+    public static void unlockAllErekirResearch() {
+        if (Planets.erekir == null || Planets.erekir.techTree == null) {
+            return;
+        }
+
+        TechNode rootNode = Planets.erekir.techTree;
+        rootNode.each(node -> { // Iterate through all nodes including children
+            if (node != null && node.content != null) {
+                if (Vars.state != null && Vars.state.rules != null && Vars.state.rules.researched != null) {
+                    Vars.state.rules.researched.add(node.content);
+                    node.content.onResearch(); // Call onResearch()
+                }
+            }
         });
     }
 }

--- a/core/src/mindustry/ui/dialogs/PlanetDialog.java
+++ b/core/src/mindustry/ui/dialogs/PlanetDialog.java
@@ -19,6 +19,7 @@ import arc.struct.*;
 import arc.util.*;
 import mindustry.*;
 import mindustry.content.*;
+import mindustry.content.ErekirTechTree; // Add this if not present
 import mindustry.content.TechTree.*;
 import mindustry.core.*;
 import mindustry.ctype.*;
@@ -204,7 +205,14 @@ public class PlanetDialog extends BaseDialog implements PlanetInterfaceRenderer{
                 diag.cont.label(() -> selected[0] == null ? "@campaign.none" : "@campaign." + selected[0].name).labelAlign(Align.center).style(Styles.outlineLabel).width(440f).wrap().colspan(2);
 
                 diag.buttons.button("@ok", Icon.ok, () -> {
-                    state.planet = selected[0];
+                    // This is the lambda to modify
+                    state.planet = selected[0]; // After this line
+
+                    // Add this conditional call
+                    if (selected[0] == Planets.erekir) {
+                        ErekirTechTree.unlockAllErekirResearch();
+                    }
+                    // Before this line (or other navigation/save calls)
                     lookAt(state.planet.getStartSector());
                     selectSector(state.planet.getStartSector());
                     settings.put("campaignselect", true);


### PR DESCRIPTION
This commit introduces a modification that automatically unlocks all research items for the Erekir planet when a new Erekir campaign is started by you.

Changes include:
- The `unlockAllErekirResearch()` method in `ErekirTechTree.java` now also calls `node.content.onResearch()` for each item to ensure proper state update.
- Modified `PlanetDialog.java` to call `ErekirTechTree.unlockAllErekirResearch()` specifically when a new Erekir campaign is selected via the initial campaign choice dialog. This ensures unlocks are applied to the new campaign's state before its first save.
- Reverted previous (ineffective) attempts to unlock research in `Vars.java` and `Universe.java`.

This approach targets the campaign initialization directly, ensuring that the unlocked research state is correctly persisted for new Erekir campaigns.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [ ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
