### PR TITLE
Fix Erekir tech tree unlock and update JDK versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,7 @@ allprojects{
     }
 
     tasks.withType(JavaCompile){
-        targetCompatibility = 8
+        targetCompatibility = JavaVersion.VERSION_17
         sourceCompatibility = JavaVersion.VERSION_17
         options.encoding = "UTF-8"
         options.compilerArgs += ["-Xlint:deprecation"]
@@ -222,10 +222,10 @@ configure(project(":annotations")){
     }
 }
 
-//compile with java 8 compatibility for everything except the annotation project
+//compile with java 17 compatibility for everything except the annotation project
 configure(subprojects - project(":annotations")){
     tasks.withType(JavaCompile){
-        options.compilerArgs.addAll(['--release', '8'])
+        options.compilerArgs.addAll(['--release', '17'])
     }
 
     tasks.withType(Javadoc){
@@ -266,7 +266,7 @@ project(":core"){
     kapt{
         javacOptions{
             option("-source", "17")
-            option("-target", "1.8")
+            option("-target", "17")
         }
     }
 

--- a/core/src/mindustry/content/ErekirTechTree.java
+++ b/core/src/mindustry/content/ErekirTechTree.java
@@ -482,7 +482,7 @@ public class ErekirTechTree{
             if (node != null && node.content != null) {
                 if (Vars.state != null && Vars.state.rules != null && Vars.state.rules.researched != null) {
                     Vars.state.rules.researched.add(node.content);
-                    node.content.onResearch(); // Call onResearch() - This line is important
+                    node.content.onUnlock(); // Call onResearch() - This line is important
                 }
             }
         });

--- a/core/src/mindustry/core/Control.java
+++ b/core/src/mindustry/core/Control.java
@@ -12,6 +12,8 @@ import arc.struct.*;
 import arc.util.*;
 import mindustry.*;
 import mindustry.audio.*;
+import mindustry.content.ErekirTechTree;
+import mindustry.content.Planets;
 import mindustry.content.*;
 import mindustry.content.TechTree.*;
 import mindustry.core.GameState.*;
@@ -517,6 +519,9 @@ public class Control implements ApplicationListener, Loadable{
         sector.info.origin = origin;
         sector.info.destination = origin;
         logic.play();
+        if(sector.planet == Planets.erekir){
+            ErekirTechTree.unlockAllErekirResearch();
+        }
         control.saves.saveSector(sector);
         Events.fire(new SectorLaunchEvent(sector));
         Events.fire(Trigger.newGame);


### PR DESCRIPTION
- Fixed a compilation error in `ErekirTechTree.java` by changing a call from the non-existent `onResearch()` to the correct `onUnlock()` method.
- Updated the project's Java version to JDK 17 for most modules in `build.gradle`. The `annotations` module remains on Java 8 due to dependencies on internal APIs. This addresses several JDK compatibility warnings.
- Ensured that the Erekir tech tree is automatically unlocked when starting a new game on an Erekir sector. This is achieved by calling `ErekirTechTree.unlockAllErekirResearch()` in the `Control.playNewSector()` method before the initial save.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [ ] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [ ] I have ensured that my code compiles, if applicable.
- [ ] I have ensured that any new features in this PR function correctly in-game, if applicable.
